### PR TITLE
chore: bump version to 0.11.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zettel-lint",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "Command line zettel linting/indexing",
   "main": "./lib/zl.js",
   "type": "module",

--- a/src/zl.ts
+++ b/src/zl.ts
@@ -10,7 +10,7 @@ import chalk from "chalk";
 // THIS import is outside `src/` folder so fails the build
 // import {version as packageVersion} from "../package.json";
 
-export const version = "0.11.11";
+export const version = "0.11.12";
 
 var program = new commander.Command("zl");
 


### PR DESCRIPTION
Fix Template filter examples and update dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version number to 0.11.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->