### PR TITLE
Create release on tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/create-release@v1
       with:
         tag_name: ${{ github.ref_name }}
-        release_name: Release ${{ github.ref_name }}
+        release_name: ${{ github.ref_name }}
         body: ${{ steps.release_notes.outputs.notes }}
         draft: false
         prerelease: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,23 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on tags with prefix 'v'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: Release ${{ github.ref_name }}
+        body: |
+          This is an automated release for tag ${{ github.ref_name }}.
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         script: |
           const { context, github } = require('@actions/github');
+          const core = require('@actions/core');
           const tagName = context.ref.replace('refs/tags/', '');
           const { data: tags } = await github.rest.repos.listTags({
             owner: context.repo.owner,

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,13 +10,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.1.1
+
+    - name: Generate Release Notes
+      id: release_notes
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { context, github } = require('@actions/github');
+          const tagName = context.ref.replace('refs/tags/', '');
+          const { data: tags } = await github.rest.repos.listTags({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+
+          const currentTagIndex = tags.findIndex(tag => tag.name === tagName);
+          if (currentTagIndex === -1 || currentTagIndex === tags.length - 1) {
+            core.setOutput('notes', 'No previous tag found.');
+            return;
+          }
+
+          const previousTag = tags[currentTagIndex + 1].name;
+          const { data: commits } = await github.rest.repos.compareCommits({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            base: previousTag,
+            head: tagName,
+          });
+
+          const commitMessages = commits.commits.map(commit => `- ${commit.commit.message}`).join('\n');
+          core.setOutput('notes', `Changes since ${previousTag}:\n\n${commitMessages}`);
+
     - name: Create GitHub Release
       uses: actions/create-release@v1
       with:
         tag_name: ${{ github.ref_name }}
         release_name: Release ${{ github.ref_name }}
-        body: |
-          This is an automated release for tag ${{ github.ref_name }}.
+        body: ${{ steps.release_notes.outputs.notes }}
         draft: false
         prerelease: false
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,6 +30,7 @@ jobs:
     - run: npm run-script zl -- index -v -i \"node_modules/**\" -r references.md --show-orphans
     - run: npm run-script zl -- notes -v -i \"node_modules/**\" --verbose --show-orphans
     - uses: butlerlogic/action-autotag@1.1.2
+      if: github.event_name == 'push'
       with:
         tag_prefix: "v"
       env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced an automated workflow to create GitHub releases with autogenerated release notes when tags are pushed.
  - Updated the Node.js CI workflow so that the autotag step only runs on push events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->