### PR TITLE
Drop node 18 support, Add node 24 support, set node 22 as default, bump minor version to reflect

### DIFF
--- a/.github/workflows/bump-patch-version.yml
+++ b/.github/workflows/bump-patch-version.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Configure Git
         run: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4.1.1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4.1.1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,7 +44,7 @@ jobs:
   #     - uses: actions/checkout@v2
   #     - uses: actions/setup-node@v1
   #       with:
-  #         node-version: 18
+  #         node-version: 22
   #         registry-url: https://npm.pkg.github.com/
   #     - run: npm ci
   #     - run: npm publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm install
       - run: npm run build
       - run: npm test
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run-script create

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zettel-lint",
-  "version": "0.11.14",
+  "version": "0.12.0",
   "description": "Command line zettel linting/indexing",
   "main": "./lib/zl.js",
   "type": "module",

--- a/replit.nix
+++ b/replit.nix
@@ -3,7 +3,7 @@
       pkgs.gh,
       pkgs.yarn,
       pkgs.esbuild,
-      pkgs.nodejs-18_x,
+      pkgs.nodejs-22_x,
       pkgs.nodePackages.typescript,
       pkgs.nodePackages.typescript-language-server
     ];

--- a/src/zl.ts
+++ b/src/zl.ts
@@ -10,7 +10,7 @@ import chalk from "chalk";
 // THIS import is outside `src/` folder so fails the build
 // import {version as packageVersion} from "../package.json";
 
-export const version = "0.11.14";
+export const version = "0.12.0";
 
 var program = new commander.Command("zl");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated automated testing to include Node.js version 24.x, ensuring compatibility with the latest Node.js releases.
	- Upgraded Node.js versions used in workflows to 22.x for patch version bumping, publishing, and development environment.
	- Released version 0.12.0 with corresponding updates reflected in package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->