### PR TITLE
Potential fix for code scanning alert no. 39: Overly permissive regular expression range

### DIFF
--- a/src/trello-import.ts
+++ b/src/trello-import.ts
@@ -184,7 +184,7 @@ export default class TrelloImport implements BaseImporter {
       "\nmodified: " + card.dateLastActivity +
       "\ntitle: '" + card.name + "'"
       "\nsource: Trello" + 
-      "\ntags:" + card.labels.map(l => l.name.replace(/[^a-zA-z0-9]/g, "_")).join(" #") +
+      "\ntags:" + card.labels.map(l => l.name.replace(/[^a-zA-Z0-9]/g, "_")).join(" #") +
       "\nreferences: " +
       (card.closed ? "\n closed: true": "") +
       (card.isTemplate ? "\n template: true": "") +


### PR DESCRIPTION
Potential fix for [https://github.com/zettel-lint/zettel-lint/security/code-scanning/39](https://github.com/zettel-lint/zettel-lint/security/code-scanning/39)

The fix is to change the regular expression to use unambiguous and correct ranges: replace `A-z` with `A-Za-z` so that the character class matches only the uppercase and lowercase English letters, as intended.  
In particular, on line 187 of `src/trello-import.ts`, change `/[^a-zA-z0-9]/g` to `/[^a-zA-Z0-9]/g`.  
No additional methods or imports are required. Only this line requires editing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
