### PR TITLE
Potential fix for code scanning alert no. 38: Overly permissive regular expression range

### DIFF
--- a/src/WikiCollector.ts
+++ b/src/WikiCollector.ts
@@ -22,5 +22,5 @@ export class WikiCollector extends RegexCollector {
     return references.map(r => "* " + formatLink(r) + " = `" + r.filename + "`:\n  * " + (r.data.length > 0 ? r.data : "No links") + "\n  * " + (backList["[" + (r.id ?? "") + "]"] ?? "No backlinks")).join("\n");
   }
   readonly dataName = "Links";
-  readonly regex = /(?:\[\d{8,14}\])|(?:\[\[[a-zA-z0-9-]*\]\])/g;
+  readonly regex = /(?:\[\d{8,14}\])|(?:\[\[[a-zA-Z0-9-]*\]\])/g;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/zettel-lint/zettel-lint/security/code-scanning/38](https://github.com/zettel-lint/zettel-lint/security/code-scanning/38)

To address the overly permissive range, we should replace `[a-zA-z0-9-]` with `[a-zA-Z0-9-]` in the regular expression on line 25 of `src/WikiCollector.ts`. This ensures only uppercase and lowercase letters, digits, and hyphens are matched inside the double-bracketed wiki links. No additional imports or definitions are needed, as this is a regex pattern correction. Edits should be made only to the definition of `readonly regex` in the class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
