### PR TITLE
Potential fix for code scanning alert no. 36: Overly permissive regular expression range

### DIFF
--- a/src/ContextCollector.ts
+++ b/src/ContextCollector.ts
@@ -13,5 +13,5 @@ export class ContextCollector extends RegexCollector {
     return result;
   };
   readonly dataName = "Contexts";
-  readonly regex = /[ ^](\@[a-zA-z0-9]+)/g;
+  readonly regex = /[ ^](\@[a-zA-Z0-9]+)/g;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/zettel-lint/zettel-lint/security/code-scanning/36](https://github.com/zettel-lint/zettel-lint/security/code-scanning/36)

To fix this problem, replace the `[a-zA-z0-9]` character class with `[a-zA-Z0-9]`. This narrows the matched characters to alphabetic (both uppercase and lowercase) and numeric, as is always intended for tagging and context extraction. Edit line 16 of `src/ContextCollector.ts` accordingly. No other imports, methods, or definitions need changing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
