### PR TITLE
fix(release): improve release notes generation by fetching all tags with pagination and using only the first line of commit messages

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -48,7 +48,6 @@ jobs:
           core.setOutput('notes', `Changes since ${previousTag}:\n\n${commitMessages}`);
 
     - name: Create GitHub Release
-    - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}


### PR DESCRIPTION
Fixes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Switched release creation to a CLI-driven step with tag verification for more consistent releases.
  - Improved tag discovery using pagination to avoid missed or incomplete tag lists in large repositories.
  - Refined release notes generation to use only the first line of each commit message for cleaner, scannable summaries.
  - Writes release notes to a file and preserves token-based authentication for the release step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->