### PR TITLE
Add concurrency guard to npm-publish workflow to prevent duplicate publishes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,7 +42,8 @@ jobs:
       - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run-script create
-      - run: npm publish
+      - run: npm publish
+
 
   # publish-gpr:
   #   needs: build


### PR DESCRIPTION
Fixes #504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced publishing workflow with improved concurrency management.
  * Updated npm registry configuration in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->