### PR TITLE
docs: Fix misleading comment in orphan links test (Templator.spec.ts) (#665)

### DIFF
--- a/src/tests/unit/Templator.spec.ts
+++ b/src/tests/unit/Templator.spec.ts
@@ -297,7 +297,7 @@ title: References
         {id: 'c', wikiname: 'c', filename: './c.md', title: 'C', fullpath: '', matchData: {}}
       ];
       const sut = new Templator(notes);
-      // Only 'c' is orphan (not referenced and doesn't reference others)
+      // Note 'b' has orphan links (references non-existent 'x')
       const result = sut.render("{{#Orphans}}{{key}}: {{#value}}{{id}}, {{/value}}{{/Orphans}}");
       expect(result).toContain("b: x");
       expect(result).not.toContain("a:");


### PR DESCRIPTION
## Issue
#665 - Misleading comment in orphan links test doesn't match what test actually checks

## Changes
- Update comment on line 300 to accurately reflect test behavior
- Comment previously said \"Only 'c' is orphan\" but test actually checks that note 'b' has orphan links
- Test assertions are correct; comment just needed updating

## Impact
Improves code clarity for other developers reading the test

## Related
Follow-up from PR #659