### PR TITLE
Switch axios to fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
-        "axios": "^1.8.2",
         "chalk": "^5.3.0",
         "clear": "^0.1.0",
         "commander": "^14.0.0",
@@ -1274,23 +1273,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
@@ -1336,19 +1318,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -1419,18 +1388,6 @@
         "node": "*"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -1493,15 +1450,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1512,71 +1460,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -1948,42 +1837,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1997,52 +1850,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2105,18 +1912,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2125,45 +1920,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/human-signals": {
@@ -2636,36 +2392,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -2991,15 +2717,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pstree.remy": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "nodemon --watch 'src/**/*.ts' --exec tsx src/zl.ts",
     "create": "npm run build && npm run test",
     "build": "tsc -p .",
+    "lint": "tsc --noEmit",
     "test": "vitest --run",
     "help": "npm run-script zl -- --version && npm run-script zl -- --help",
     "refresh": "rm -rf ./node_modules ./package-lock.json && npm install",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "homepage": "https://github.com/zettel-lint/zettel-lint#readme",
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
-    "axios": "^1.8.2",
     "chalk": "^5.3.0",
     "clear": "^0.1.0",
     "commander": "^14.0.0",

--- a/src/base-importer.ts
+++ b/src/base-importer.ts
@@ -4,6 +4,11 @@ export class ErrorResponse {
 
 }
 
+export type ImportOptions = {
+    verbose?: boolean;
+    [key: string]: any; // Allow additional options
+}
+
 export interface BaseImporter {
-    importAsync(globpattern: string, outputFolder: string) : Promise<ErrorResponse>;
+    importAsync(globpattern: string, outputFolder: string, options: ImportOptions) : Promise<ErrorResponse>;
 }

--- a/src/tests/unit/trello-import.spec.ts
+++ b/src/tests/unit/trello-import.spec.ts
@@ -298,6 +298,17 @@ describe('TrelloImport', () => {
       expect(result).toEqual([]);
       consoleErrorSpy.mockRestore();
     });
+
+    test('no file written if fetch fails', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, statusText: 'Not Found' });
+      const attachment = createAttachmentInfo({ url: 'https://example.com/missing.png' });
+
+      const result = await importer.saveAttachments('/output/', options, [attachment]);
+
+      expect(fetch).toHaveBeenCalledWith('https://example.com/missing.png');
+      expect(fs.writeFile).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
   });
 
   describe('sanitiseName', () => {
@@ -700,7 +711,25 @@ describe('TrelloImport', () => {
       consoleLogSpy.mockRestore();
     });
 
-    test('throws error when board name lookup requires token but none provided', async () => {
+    test('throws error when board ID is invalid and name lookup fails', async () => {
+      const mockBoards = [
+        { id: 'board1', name: 'My Board' },
+        { id: 'board2', name: 'Other Board' },
+      ];
+      vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockBoards) });
+
+      await expect(
+        TrelloImport.downloadBoardJson({
+          boardIdOrName: 'Invalid Board',
+          apiKey: 'test-key',
+          token: 'test-token',
+        })
+      ).rejects.toThrow('Could not find Trello board');
+    });
+
+    test('throws error when fetch returns unsuccessful HTTP status during board download', async () => {
+      vi.mocked(fetch).mockResolvedValue({ ok: false, statusText: 'Not Found' });
+
       await expect(
         TrelloImport.downloadBoardJson({
           boardIdOrName: 'My Board Name',

--- a/src/tests/unit/trello-import.spec.ts
+++ b/src/tests/unit/trello-import.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import TrelloImport from '../../trello-import.js';
 import { promises as fs } from 'fs';
 import { glob } from 'glob';
-import { ok } from 'assert';
 
 // Mock dependencies
 vi.mock('fs', () => ({

--- a/src/tests/unit/trello-import.spec.ts
+++ b/src/tests/unit/trello-import.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import TrelloImport from '../../trello-import.js';
 import { promises as fs } from 'fs';
-import axios from 'axios';
 import { glob } from 'glob';
 
 // Mock dependencies
@@ -11,8 +10,6 @@ vi.mock('fs', () => ({
     writeFile: vi.fn(),
   }
 }));
-
-vi.mock('axios');
 
 vi.mock('glob', () => ({
   glob: vi.fn(),
@@ -217,7 +214,7 @@ describe('TrelloImport', () => {
   describe('saveAttachments', () => {
     beforeEach(() => {
       vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-      vi.mocked(axios.get).mockResolvedValue({ data: Buffer.from('test data') });
+      vi.mocked(fetch).mockResolvedValue({ data: Buffer.from('test data') });
     });
 
     test('saves file attachments successfully', async () => {
@@ -229,7 +226,7 @@ describe('TrelloImport', () => {
 
       const result = await importer.saveAttachments('/output/', [attachment]);
 
-      expect(axios.get).toHaveBeenCalledWith('https://example.com/test.png', { responseType: 'arraybuffer' });
+      expect(fetch).toHaveBeenCalledWith('https://example.com/test.png');
       expect(fs.writeFile).toHaveBeenCalledWith('/output/test.png', expect.any(Buffer));
       expect(result).toEqual(['![Test Image](/output/test.png)']);
     });
@@ -243,7 +240,7 @@ describe('TrelloImport', () => {
 
       const result = await importer.saveAttachments('/output/', [attachment]);
 
-      expect(axios.get).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
       expect(result).toEqual(['[External Link](https://example.com/page)']);
     });
@@ -257,7 +254,7 @@ describe('TrelloImport', () => {
 
       const result = await importer.saveAttachments('/output/', [attachment]);
 
-      expect(axios.get).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
       expect(result).toEqual(['[Null File](https://example.com/null)']);
     });
 
@@ -269,7 +266,7 @@ describe('TrelloImport', () => {
 
       const result = await importer.saveAttachments('/output/', attachments);
 
-      expect(axios.get).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenCalledTimes(2);
       expect(fs.writeFile).toHaveBeenCalledTimes(2);
       expect(result).toHaveLength(2);
       expect(result[0]).toContain('File 1');
@@ -279,14 +276,14 @@ describe('TrelloImport', () => {
     test('handles empty attachments array', async () => {
       const result = await importer.saveAttachments('/output/', []);
 
-      expect(axios.get).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
       expect(result).toEqual([]);
     });
 
     test('continues on error and logs to console', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      vi.mocked(axios.get).mockRejectedValueOnce(new Error('Network error'));
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
       const attachment = createAttachmentInfo({ fileName: 'test.png' });
 
       const result = await importer.saveAttachments('/output/', [attachment]);
@@ -320,7 +317,7 @@ describe('TrelloImport', () => {
   describe('writeCard', () => {
     beforeEach(() => {
       vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-      vi.mocked(axios.get).mockResolvedValue({ data: Buffer.from('test') });
+      vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
     });
 
     test('writes card without checklists or attachments', async () => {
@@ -457,7 +454,7 @@ describe('TrelloImport', () => {
   describe('importAsync', () => {
     beforeEach(() => {
       vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-      vi.mocked(axios.get).mockResolvedValue({ data: Buffer.from('test') });
+      vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
     });
 
     test('returns error when no files match glob pattern', async () => {
@@ -642,14 +639,14 @@ describe('TrelloImport', () => {
   describe('downloadBoardJson', () => {
     test('downloads board by valid ID', async () => {
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(axios.get).mockResolvedValue({ data: mockBoard });
+      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
 
       const result = await TrelloImport.downloadBoardJson({
         boardIdOrName: '507f1f77bcf86cd799439011',
         apiKey: 'test-key',
       });
 
-      expect(axios.get).toHaveBeenCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('507f1f77bcf86cd799439011'),
       );
       expect(result).toEqual(mockBoard);
@@ -657,14 +654,14 @@ describe('TrelloImport', () => {
 
     test('downloads board by 8-character ID', async () => {
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(axios.get).mockResolvedValue({ data: mockBoard });
+      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
 
       const result = await TrelloImport.downloadBoardJson({
         boardIdOrName: 'abc12345',
         apiKey: 'test-key',
       });
 
-      expect(axios.get).toHaveBeenCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('abc12345'),
       );
       expect(result).toEqual(mockBoard);
@@ -677,9 +674,9 @@ describe('TrelloImport', () => {
         { id: 'board2', name: 'Other Board' },
       ];
       const mockBoard = createTrelloBoardInfo({ id: 'board1', name: 'My Board' });
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ data: mockBoards })
-        .mockResolvedValueOnce({ data: mockBoard });
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockBoards) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockBoard) });
 
       const result = await TrelloImport.downloadBoardJson({
         boardIdOrName: 'My Board',
@@ -687,10 +684,10 @@ describe('TrelloImport', () => {
         token: 'test-token',
       });
 
-      expect(axios.get).toHaveBeenCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('/members/me/boards'),
       );
-      expect(axios.get).toHaveBeenCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('board1'),
       );
       expect(result).toEqual(mockBoard);
@@ -711,7 +708,7 @@ describe('TrelloImport', () => {
         { id: 'board1', name: 'Board One' },
         { id: 'board2', name: 'Board Two' },
       ];
-      vi.mocked(axios.get).mockResolvedValue({ data: mockBoards });
+      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoards) });
 
       await expect(
         TrelloImport.downloadBoardJson({
@@ -724,7 +721,7 @@ describe('TrelloImport', () => {
 
     test('includes token in board download URL when provided', async () => {
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(axios.get).mockResolvedValue({ data: mockBoard });
+      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
 
       await TrelloImport.downloadBoardJson({
         boardIdOrName: 'abc12345',
@@ -732,28 +729,28 @@ describe('TrelloImport', () => {
         token: 'test-token',
       });
 
-      expect(axios.get).toHaveBeenCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('&token=test-token'),
       );
     });
 
     test('omits token from URL when not provided', async () => {
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(axios.get).mockResolvedValue({ data: mockBoard });
+      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
 
       await TrelloImport.downloadBoardJson({
         boardIdOrName: 'abc12345',
         apiKey: 'test-key',
       });
 
-      const url = vi.mocked(axios.get).mock.calls[0][0];
+      const url = vi.mocked(fetch).mock.calls[0][0];
       expect(url).not.toContain('&token=');
     });
 
     test('logs verbose output when enabled', async () => {
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(axios.get).mockResolvedValue({ data: mockBoard });
+      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
 
       await TrelloImport.downloadBoardJson({
         boardIdOrName: 'abc12345',
@@ -771,9 +768,9 @@ describe('TrelloImport', () => {
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const mockBoards = [{ id: 'board1', name: 'My Board' }];
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(axios.get)
-        .mockResolvedValueOnce({ data: mockBoards })
-        .mockResolvedValueOnce({ data: mockBoard });
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockBoards) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockBoard) });
 
       await TrelloImport.downloadBoardJson({
         boardIdOrName: 'My Board',
@@ -792,7 +789,7 @@ describe('TrelloImport', () => {
     });
 
     test('handles API errors gracefully', async () => {
-      vi.mocked(axios.get).mockRejectedValue(new Error('API Error'));
+      vi.mocked(fetch).mockRejectedValue(new Error('API Error'));
 
       await expect(
         TrelloImport.downloadBoardJson({
@@ -863,7 +860,7 @@ describe('TrelloImport', () => {
       });
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
-      vi.mocked(axios.get).mockResolvedValue({ data: Buffer.from('test') });
+      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(Buffer.from('test')) });
 
       const result = await importer.importAsync('*.json', '/output/');
 

--- a/src/tests/unit/trello-import.spec.ts
+++ b/src/tests/unit/trello-import.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import TrelloImport from '../../trello-import.js';
 import { promises as fs } from 'fs';
 import { glob } from 'glob';
-import { arrayBuffer } from 'stream/consumers';
 
 // Mock dependencies
 vi.mock('fs', () => ({
@@ -104,6 +103,7 @@ const createTrelloBoardInfo = (overrides = {}) => ({
   ...overrides,
 });
 
+const options = { boardIdOrName: 'board1', apiKey: 'api_key', token: 'token' };
 describe('TrelloImport', () => {
   let importer: TrelloImport;
 
@@ -230,7 +230,7 @@ describe('TrelloImport', () => {
         url: 'https://example.com/test.png',
       });
 
-      const result = await importer.saveAttachments('/output/', [attachment]);
+      const result = await importer.saveAttachments('/output/', options, [attachment]);
 
       expect(fetch).toHaveBeenCalledWith('https://example.com/test.png');
       expect(fs.writeFile).toHaveBeenCalledWith('/output/test.png', expect.any(Buffer));
@@ -244,7 +244,7 @@ describe('TrelloImport', () => {
         url: 'https://example.com/page',
       });
 
-      const result = await importer.saveAttachments('/output/', [attachment]);
+      const result = await importer.saveAttachments('/output/', options, [attachment]);
 
       expect(fetch).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
@@ -258,7 +258,7 @@ describe('TrelloImport', () => {
         url: 'https://example.com/null',
       });
 
-      const result = await importer.saveAttachments('/output/', [attachment]);
+      const result = await importer.saveAttachments('/output/', options, [attachment]);
 
       expect(fetch).not.toHaveBeenCalled();
       expect(result).toEqual(['[Null File](https://example.com/null)']);
@@ -270,7 +270,7 @@ describe('TrelloImport', () => {
         createAttachmentInfo({ fileName: 'file2.jpg', name: 'File 2', url: 'https://example.com/2.jpg' }),
       ];
 
-      const result = await importer.saveAttachments('/output/', attachments);
+      const result = await importer.saveAttachments('/output/', options, attachments);
 
       expect(fetch).toHaveBeenCalledTimes(2);
       expect(fs.writeFile).toHaveBeenCalledTimes(2);
@@ -280,7 +280,7 @@ describe('TrelloImport', () => {
     });
 
     test('handles empty attachments array', async () => {
-      const result = await importer.saveAttachments('/output/', []);
+      const result = await importer.saveAttachments('/output/', options, []);
 
       expect(fetch).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
@@ -292,7 +292,7 @@ describe('TrelloImport', () => {
       vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
       const attachment = createAttachmentInfo({ fileName: 'test.png' });
 
-      const result = await importer.saveAttachments('/output/', [attachment]);
+      const result = await importer.saveAttachments('/output/', options, [attachment]);
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Could not write file'));
       expect(result).toEqual([]);
@@ -330,7 +330,7 @@ describe('TrelloImport', () => {
       const card = createTrelloCardInfo({ name: 'Simple Card', desc: 'Simple description' });
       const lists = { list1: createTrelloListInfo() };
 
-      const result = await importer.writeCard('/output/', 'Test Board', card, {}, lists);
+      const result = await importer.writeCard('/output/', options, 'Test Board', card, {}, lists);
 
       expect(result).toBe(true);
       expect(fs.writeFile).toHaveBeenCalled();
@@ -353,7 +353,7 @@ describe('TrelloImport', () => {
       const checklists = { cl1: checklist };
       const lists = { list1: createTrelloListInfo() };
 
-      const result = await importer.writeCard('/output/', 'Board', card, checklists, lists);
+      const result = await importer.writeCard('/output/', options, 'Board', card, checklists, lists);
 
       expect(result).toBe(true);
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
@@ -368,7 +368,7 @@ describe('TrelloImport', () => {
       });
       const lists = { list1: createTrelloListInfo() };
 
-      const result = await importer.writeCard('/output/', 'Board', card, {}, lists);
+      const result = await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       expect(result).toBe(true);
       // Index 0 is the attachment file, index 1 is the card markdown file
@@ -380,7 +380,7 @@ describe('TrelloImport', () => {
       const card = createTrelloCardInfo({ closed: true });
       const lists = { list1: createTrelloListInfo() };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain('closed: true');
@@ -390,7 +390,7 @@ describe('TrelloImport', () => {
       const card = createTrelloCardInfo({ isTemplate: true });
       const lists = { list1: createTrelloListInfo() };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain('template: true');
@@ -405,7 +405,7 @@ describe('TrelloImport', () => {
       });
       const lists = { list1: createTrelloListInfo() };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain('tags:Important #Bug_Fix');
@@ -417,7 +417,7 @@ describe('TrelloImport', () => {
         list1: createTrelloListInfo({ name: 'Published Articles' }),
       };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain('published: true');
@@ -429,7 +429,7 @@ describe('TrelloImport', () => {
       const card = createTrelloCardInfo();
       const lists = { list1: createTrelloListInfo() };
 
-      const result = await importer.writeCard('/output/', 'Board', card, {}, lists);
+      const result = await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Could not write file'));
@@ -440,7 +440,7 @@ describe('TrelloImport', () => {
       const card = createTrelloCardInfo({ name: 'Test@Card#Name$With%Special&Chars' });
       const lists = { list1: createTrelloListInfo() };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const filename = vi.mocked(fs.writeFile).mock.calls[0][0] as string;
       expect(filename).toMatch(/Test-Card-Name-With-Special-Chars\.md$/);
@@ -450,7 +450,7 @@ describe('TrelloImport', () => {
       const card = createTrelloCardInfo({ shortUrl: 'https://trello.com/c/abc123' });
       const lists = { list1: createTrelloListInfo() };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain("trello-url: 'https://trello.com/c/abc123'");
@@ -466,7 +466,7 @@ describe('TrelloImport', () => {
     test('returns error when no files match glob pattern', async () => {
       vi.mocked(glob).mockResolvedValue([]);
 
-      const result = await importer.importAsync('*.json', '/output/');
+      const result = await importer.importAsync('*.json', '/output/', options);
 
       expect(result.success).toBe(false);
       expect(result.message).toContain('No files found');
@@ -481,7 +481,7 @@ describe('TrelloImport', () => {
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
 
-      const result = await importer.importAsync('board.json', '/output/');
+      const result = await importer.importAsync('board.json', '/output/', options);
 
       expect(result.success).toBe(true);
       expect(result.message).toContain('1 cards found');
@@ -498,7 +498,7 @@ describe('TrelloImport', () => {
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
 
-      await importer.importAsync('*.json', '/output');
+      await importer.importAsync('*.json', '/output/', options);
 
       const filename = vi.mocked(fs.writeFile).mock.calls[0]?.[0] as string;
       expect(filename).toContain('/output/');
@@ -520,7 +520,7 @@ describe('TrelloImport', () => {
         .mockResolvedValueOnce(JSON.stringify(board1))
         .mockResolvedValueOnce(JSON.stringify(board2));
 
-      const result = await importer.importAsync('*.json', '/output/');
+      const result = await importer.importAsync('*.json', '/output/', options);
 
       expect(result.success).toBe(true);
       expect(result.message).toContain('2 cards found');
@@ -540,7 +540,7 @@ describe('TrelloImport', () => {
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
 
-      const result = await importer.importAsync('*.json', '/output/');
+      const result = await importer.importAsync('*.json', '/output/', options);
 
       expect(result.message).toContain('2 cards found');
       expect(result.message).toContain('1 notes created');
@@ -559,7 +559,7 @@ describe('TrelloImport', () => {
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
 
-      const result = await importer.importAsync('*.json', '/output/');
+      const result = await importer.importAsync('*.json', '/output/', options);
 
       expect(result.message).toContain('2 cards found');
       expect(result.message).toContain('1 notes created');
@@ -581,7 +581,7 @@ describe('TrelloImport', () => {
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
 
-      const result = await importer.importAsync('*.json', '/output/');
+      const result = await importer.importAsync('*.json', '/output/', options);
 
       expect(result.message).toContain('2 cards found');
       expect(result.message).toContain('1 notes created');
@@ -604,7 +604,7 @@ describe('TrelloImport', () => {
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
 
-      await importer.importAsync('*.json', '/output/');
+      await importer.importAsync('*.json', '/output/', options);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain('### Tasks');
@@ -622,7 +622,7 @@ describe('TrelloImport', () => {
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
 
-      await importer.importAsync('*.json', '/output/');
+      await importer.importAsync('*.json', '/output/', options);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain("list: 'In Progress'");
@@ -635,7 +635,7 @@ describe('TrelloImport', () => {
       vi.mocked(glob).mockResolvedValue(['board1.json', 'board2.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
 
-      await importer.importAsync('*.json', '/output/');
+      await importer.importAsync('*.json', '/output/', options);
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('2 files found'));
       consoleWarnSpy.mockRestore();
@@ -811,7 +811,7 @@ describe('TrelloImport', () => {
       const card = createTrelloCardInfo({ desc: '' });
       const lists = { list1: createTrelloListInfo() };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain('## Test Card');
@@ -821,7 +821,7 @@ describe('TrelloImport', () => {
       const card = createTrelloCardInfo({ name: 'Card: With / Special \\ Characters?' });
       const lists = { list1: createTrelloListInfo() };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const filename = vi.mocked(fs.writeFile).mock.calls[0][0] as string;
       // Should sanitize special characters in filename (check basename only, not path)
@@ -838,7 +838,7 @@ describe('TrelloImport', () => {
       });
       const lists = { list1: createTrelloListInfo() };
 
-      await importer.writeCard('/output/', 'Board', card, {}, lists);
+      await importer.writeCard('/output/', options, 'Board', card, {}, lists);
 
       const content = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
       expect(content).toContain('tags:Label_With_Spaces_');
@@ -868,7 +868,7 @@ describe('TrelloImport', () => {
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
       vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
 
-      const result = await importer.importAsync('*.json', '/output/');
+      const result = await importer.importAsync('*.json', '/output/', options);
 
       expect(result.success).toBe(true);
       const content = vi.mocked(fs.writeFile).mock.calls[1][1] as string; // [0] is attachment, [1] is card

--- a/src/tests/unit/trello-import.spec.ts
+++ b/src/tests/unit/trello-import.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import TrelloImport from '../../trello-import.js';
 import { promises as fs } from 'fs';
 import { glob } from 'glob';
+import { arrayBuffer } from 'stream/consumers';
 
 // Mock dependencies
 vi.mock('fs', () => ({
@@ -14,6 +15,8 @@ vi.mock('fs', () => ({
 vi.mock('glob', () => ({
   glob: vi.fn(),
 }));
+
+global.fetch = vi.fn();
 
 // Helper to create test data
 const createTrelloCheckItemInfo = (overrides = {}) => ({
@@ -214,7 +217,7 @@ describe('TrelloImport', () => {
   describe('saveAttachments', () => {
     beforeEach(() => {
       vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-      vi.mocked(fetch).mockResolvedValue({ data: Buffer.from('test data') });
+      vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test data')) });
     });
 
     test('saves file attachments successfully', async () => {
@@ -860,7 +863,7 @@ describe('TrelloImport', () => {
       });
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
-      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(Buffer.from('test')) });
+      vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
 
       const result = await importer.importAsync('*.json', '/output/');
 

--- a/src/tests/unit/trello-import.spec.ts
+++ b/src/tests/unit/trello-import.spec.ts
@@ -16,8 +16,6 @@ vi.mock('glob', () => ({
   glob: vi.fn(),
 }));
 
-global.fetch = vi.fn();
-
 // Helper to create test data
 const createTrelloCheckItemInfo = (overrides = {}) => ({
   id: 'item1',
@@ -112,6 +110,11 @@ describe('TrelloImport', () => {
   beforeEach(() => {
     importer = new TrelloImport();
     vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   describe('sortableDate', () => {

--- a/src/tests/unit/trello-import.spec.ts
+++ b/src/tests/unit/trello-import.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import TrelloImport from '../../trello-import.js';
 import { promises as fs } from 'fs';
 import { glob } from 'glob';
+import { ok } from 'assert';
 
 // Mock dependencies
 vi.mock('fs', () => ({
@@ -220,7 +221,7 @@ describe('TrelloImport', () => {
   describe('saveAttachments', () => {
     beforeEach(() => {
       vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-      vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test data')) });
+      vi.mocked(fetch).mockResolvedValue({ ok: true, arrayBuffer: () => Promise.resolve(Buffer.from('test data')) });
     });
 
     test('saves file attachments successfully', async () => {
@@ -323,7 +324,7 @@ describe('TrelloImport', () => {
   describe('writeCard', () => {
     beforeEach(() => {
       vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-      vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
+      vi.mocked(fetch).mockResolvedValue({ok: true, arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
     });
 
     test('writes card without checklists or attachments', async () => {
@@ -460,7 +461,7 @@ describe('TrelloImport', () => {
   describe('importAsync', () => {
     beforeEach(() => {
       vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-      vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
+      vi.mocked(fetch).mockResolvedValue({ok: true, arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
     });
 
     test('returns error when no files match glob pattern', async () => {
@@ -645,7 +646,7 @@ describe('TrelloImport', () => {
   describe('downloadBoardJson', () => {
     test('downloads board by valid ID', async () => {
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
+      vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockBoard) });
 
       const result = await TrelloImport.downloadBoardJson({
         boardIdOrName: '507f1f77bcf86cd799439011',
@@ -660,7 +661,7 @@ describe('TrelloImport', () => {
 
     test('downloads board by 8-character ID', async () => {
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
+      vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockBoard) });
 
       const result = await TrelloImport.downloadBoardJson({
         boardIdOrName: 'abc12345',
@@ -681,8 +682,8 @@ describe('TrelloImport', () => {
       ];
       const mockBoard = createTrelloBoardInfo({ id: 'board1', name: 'My Board' });
       vi.mocked(fetch)
-        .mockResolvedValueOnce({ json: () => Promise.resolve(mockBoards) })
-        .mockResolvedValueOnce({ json: () => Promise.resolve(mockBoard) });
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockBoards) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockBoard) });
 
       const result = await TrelloImport.downloadBoardJson({
         boardIdOrName: 'My Board',
@@ -714,7 +715,7 @@ describe('TrelloImport', () => {
         { id: 'board1', name: 'Board One' },
         { id: 'board2', name: 'Board Two' },
       ];
-      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoards) });
+      vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockBoards) });
 
       await expect(
         TrelloImport.downloadBoardJson({
@@ -727,7 +728,7 @@ describe('TrelloImport', () => {
 
     test('includes token in board download URL when provided', async () => {
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
+      vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockBoard) });
 
       await TrelloImport.downloadBoardJson({
         boardIdOrName: 'abc12345',
@@ -742,7 +743,7 @@ describe('TrelloImport', () => {
 
     test('omits token from URL when not provided', async () => {
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
+      vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockBoard) });
 
       await TrelloImport.downloadBoardJson({
         boardIdOrName: 'abc12345',
@@ -756,7 +757,7 @@ describe('TrelloImport', () => {
     test('logs verbose output when enabled', async () => {
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const mockBoard = createTrelloBoardInfo();
-      vi.mocked(fetch).mockResolvedValue({ json: () => Promise.resolve(mockBoard) });
+      vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve(mockBoard) });
 
       await TrelloImport.downloadBoardJson({
         boardIdOrName: 'abc12345',
@@ -775,8 +776,8 @@ describe('TrelloImport', () => {
       const mockBoards = [{ id: 'board1', name: 'My Board' }];
       const mockBoard = createTrelloBoardInfo();
       vi.mocked(fetch)
-        .mockResolvedValueOnce({ json: () => Promise.resolve(mockBoards) })
-        .mockResolvedValueOnce({ json: () => Promise.resolve(mockBoard) });
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockBoards) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockBoard) });
 
       await TrelloImport.downloadBoardJson({
         boardIdOrName: 'My Board',
@@ -866,7 +867,7 @@ describe('TrelloImport', () => {
       });
       vi.mocked(glob).mockResolvedValue(['board.json']);
       vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(board));
-      vi.mocked(fetch).mockResolvedValue({ arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
+      vi.mocked(fetch).mockResolvedValue({ ok: true, arrayBuffer: () => Promise.resolve(Buffer.from('test')) });
 
       const result = await importer.importAsync('*.json', '/output/', options);
 

--- a/src/trello-import.ts
+++ b/src/trello-import.ts
@@ -103,6 +103,14 @@ export type TrelloOptions = ImportOptions & {
 };
 
 export default class TrelloImport implements BaseImporter {
+  private static async fetchJsonOrThrow(url: string, context: string): Promise<any> {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${context}: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
   static async downloadBoardJson(options: TrelloOptions): Promise<any> {
     let { boardIdOrName, apiKey, token, verbose } = options;
     // If not a Trello board id (alphanumeric, 8 or 24 chars), look up by name
@@ -114,8 +122,7 @@ export default class TrelloImport implements BaseImporter {
         throw new Error("A Trello token (--trello-token) is required to look up boards by name.");
       }
       const boardsUrl = `https://api.trello.com/1/members/me/boards?key=${apiKey}&token=${token}`;
-      const boardsRes = await fetch(boardsUrl);
-      const boards = await boardsRes.json();
+      const boards = await TrelloImport.fetchJsonOrThrow(boardsUrl, "Trello board lookup");
       const found = boards.find((b: any) => b.name === boardIdOrName);
       if (!found) {
         throw new Error(`Could not find Trello board with name: ${boardIdOrName}`);
@@ -129,8 +136,7 @@ export default class TrelloImport implements BaseImporter {
     if (verbose) {
       console.log(`Downloading Trello board ${boardIdOrName}`);
     }
-    const res = await fetch(url);
-    return res.json();
+    return TrelloImport.fetchJsonOrThrow(url, "Trello board download");
   }
   async extractNotes(filename: string) : Promise<TrelloBoardInfo> {
     const contents = await fs.readFile(filename, "utf8");
@@ -159,6 +165,9 @@ export default class TrelloImport implements BaseImporter {
       }      
       try {
         const response = await fetch(attachment.url);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch attachment [${attachment.name}](${attachment.url}): ${response.status} ${response.statusText}`);
+        }
         const data = await response.arrayBuffer();
         await fs.writeFile(outputFilename, Buffer.from(data));
         filenames.push("![" + attachment.name + "](" + outputFilename + ")");

--- a/src/trello-import.ts
+++ b/src/trello-import.ts
@@ -1,4 +1,4 @@
-import { BaseImporter, ErrorResponse } from "./base-importer.js"
+import { BaseImporter, ErrorResponse, ImportOptions } from "./base-importer.js"
 import { glob } from "glob";
 import { promises as fs } from "fs";
 import { min } from "./types.js";
@@ -96,13 +96,14 @@ function sortableDate(d: Date) : string {
   return ("" + d).replace(/[^0-9]/g,"").substring(0,14);
 }
 
+export type TrelloOptions = ImportOptions & {
+  boardIdOrName: string;
+  apiKey: string;
+  token?: string;
+};
+
 export default class TrelloImport implements BaseImporter {
-  static async downloadBoardJson(options: {
-    boardIdOrName: string,
-    apiKey: string,
-    token?: string,
-    verbose?: boolean
-  }): Promise<any> {
+  static async downloadBoardJson(options: TrelloOptions): Promise<any> {
     let { boardIdOrName, apiKey, token, verbose } = options;
     // If not a Trello board id (alphanumeric, 8 or 24 chars), look up by name
     if (!/^([0-9a-f]{8}|[0-9a-f]{24})$/i.test(boardIdOrName)) {
@@ -143,13 +144,14 @@ export default class TrelloImport implements BaseImporter {
       cl.checkItems.map(ci => "* [" + (ci.state === "complete" ? "X" : " ") + "] " + ci.name + (ci.due ? " due:" + ci.due.toISOString() : "")).join("\n");
   }
 
-  async saveAttachments(outputFolder: string, attachments: AttachmentInfo[]) : Promise<string[]> {
+  async saveAttachments(outputFolder: string, options: TrelloOptions, attachments: AttachmentInfo[]) : Promise<string[]> {
     var filenames: string[] = [];
 
     for await (var attachment of attachments) {
       const outputFilename = outputFolder + attachment.fileName;  
-      // TODO : Add Verbose clause here
-      // console.log("Writing attachment " + attachment.id + " from " + attachment.url + " to " + outputFilename + " of type " + attachment.mimeType);
+      if (options.verbose) {
+       console.log("Writing attachment " + attachment.id + " from " + attachment.url + " to " + outputFilename + " of type " + attachment.mimeType);
+      }
       if (attachment.fileName == null || attachment.fileName === "null" || attachment.fileName === "") {
         // It's a URL
         filenames.push("[" + attachment.name + "](" + attachment.url + ")");
@@ -168,6 +170,7 @@ export default class TrelloImport implements BaseImporter {
   }
 
   async writeCard(outputFolder: string,
+      options: TrelloOptions,
       boardName: string,
       card: TrelloCardInfo,
       checklists : { [id: string]: TrelloChecklistInfo; },
@@ -176,7 +179,7 @@ export default class TrelloImport implements BaseImporter {
       sortableDate(card.dateLastActivity) + 
       "-" + this.sanitiseName(card) + ".md";
 
-    const filenames = await this.saveAttachments(outputFolder + "attachments/", card.attachments || []);
+    const filenames = await this.saveAttachments(outputFolder + "attachments/", options, card.attachments || []);
 
     const header = "---" +
       "\ncreated: " + card.dateLastActivity +
@@ -196,7 +199,7 @@ export default class TrelloImport implements BaseImporter {
       "\n\n";
     
     try {
-      await fs.writeFile(outputFilename, 
+      await fs.writeFile(outputFilename,
         header + 
         card.desc + 
 
@@ -214,7 +217,7 @@ export default class TrelloImport implements BaseImporter {
     return card.name.replace(/[^A-Za-z0-9]/gm, '-').slice(0, min(50, card.name.length));
   }
 
-  async importAsync(globpattern: string, outputFolder: string): Promise<ErrorResponse> {
+  async importAsync(globpattern: string, outputFolder: string, options: TrelloOptions): Promise<ErrorResponse> {
     // Ensure output folder exists and has a path separator at the end
     if (!outputFolder.endsWith("/")) {
       outputFolder += "/";
@@ -243,7 +246,7 @@ export default class TrelloImport implements BaseImporter {
         labels[label.id] = label;
       })
       for await(const note of notes.cards) {
-        if(!note.closed && !note.isTemplate && !lists[note.idList].closed && await this.writeCard(outputFolder, notes.name, note, checklists, lists)) {
+        if(!note.closed && !note.isTemplate && !lists[note.idList].closed && await this.writeCard(outputFolder, options, notes.name, note, checklists, lists)) {
           totalNotes++;
         }
       }

--- a/src/trello-import.ts
+++ b/src/trello-import.ts
@@ -1,7 +1,6 @@
 import { BaseImporter, ErrorResponse } from "./base-importer.js"
 import { glob } from "glob";
 import { promises as fs } from "fs";
-import axios from "axios";
 import { min } from "./types.js";
 
 class NoteInfo {
@@ -114,8 +113,8 @@ export default class TrelloImport implements BaseImporter {
         throw new Error("A Trello token (--trello-token) is required to look up boards by name.");
       }
       const boardsUrl = `https://api.trello.com/1/members/me/boards?key=${apiKey}&token=${token}`;
-      const boardsRes = await axios.get(boardsUrl);
-      const boards = boardsRes.data;
+      const boardsRes = await fetch(boardsUrl);
+      const boards = await boardsRes.json();
       const found = boards.find((b: any) => b.name === boardIdOrName);
       if (!found) {
         throw new Error(`Could not find Trello board with name: ${boardIdOrName}`);
@@ -129,8 +128,8 @@ export default class TrelloImport implements BaseImporter {
     if (verbose) {
       console.log(`Downloading Trello board ${boardIdOrName}`);
     }
-    const res = await axios.get(url);
-    return res.data;
+    const res = await fetch(url);
+    return res.json();
   }
   async extractNotes(filename: string) : Promise<TrelloBoardInfo> {
     const contents = await fs.readFile(filename, "utf8");
@@ -157,9 +156,9 @@ export default class TrelloImport implements BaseImporter {
         continue;
       }      
       try {
-        const response = await axios.get(attachment.url, { responseType: "arraybuffer"});
-        const data = await response.data;
-        await fs.writeFile(outputFilename, data);
+        const response = await fetch(attachment.url);
+        const data = await response.arrayBuffer();
+        await fs.writeFile(outputFilename, Buffer.from(data));
         filenames.push("![" + attachment.name + "](" + outputFilename + ")");
       } catch (error) {
         console.error("Could not write file " + outputFilename + " because " + error);
@@ -199,7 +198,8 @@ export default class TrelloImport implements BaseImporter {
     try {
       await fs.writeFile(outputFilename, 
         header + 
-        card.desc + 
+        card.desc + 
+
         (card.idChecklists.length > 0 ? "\n\n---\n\n## Checklists\n\n" + card.idChecklists.map(checklistId => this.writeCheckList(checklists[checklistId])).join("\n\n") : "") +
         (filenames.length > 0 ? "\n\n---\n\n## Attachments\n\n* " + filenames.join("\n* ") : "")
         , { });

--- a/src/zl-import.ts
+++ b/src/zl-import.ts
@@ -4,7 +4,7 @@ import clear from "clear";
 import chalk from "chalk";
 import figlet from "figlet";
 import { Command } from '@commander-js/extra-typings';
-import TrelloImport from "./trello-import.js";
+import TrelloImport, { TrelloOptions } from "./trello-import.js";
 import { ErrorResponse } from "./base-importer.js";
 
 interface ZlImportOptions {
@@ -64,19 +64,23 @@ async function importer(program: ZlImportOptions): Promise<void> {
 
   async function parseFiles() {
     let response: ErrorResponse;
+      const options : TrelloOptions = {
+        verbose: program.verbose,
+        boardIdOrName: program.trelloBoard || "<missing>",
+        apiKey: program.trelloApiKey || "<missing>",
+        token: program.trelloToken || "<missing>",
+      };
     if (
       program.source === "trello" &&
       program.trelloApiKey &&
       program.trelloBoard
     ) {
+      options.apiKey = program.trelloApiKey;
+      options.boardIdOrName = program.trelloBoard;
+      options.token = program.trelloToken;
+
       // Download board JSON from Trello API using TrelloImport helper
       try {
-        const options = {
-          boardIdOrName: program.trelloBoard,
-          apiKey: program.trelloApiKey,
-          token: program.trelloToken,
-          verbose: program.verbose
-        };
         const boardJson = await TrelloImport.downloadBoardJson(options);
         if (program.jsonDebugOutput) {
           console.log("Trello board JSON:", JSON.stringify(boardJson, null, 2));

--- a/src/zl-import.ts
+++ b/src/zl-import.ts
@@ -71,12 +71,13 @@ async function importer(program: ZlImportOptions): Promise<void> {
     ) {
       // Download board JSON from Trello API using TrelloImport helper
       try {
-        const boardJson = await TrelloImport.downloadBoardJson({
+        const options = {
           boardIdOrName: program.trelloBoard,
           apiKey: program.trelloApiKey,
           token: program.trelloToken,
           verbose: program.verbose
-        });
+        };
+        const boardJson = await TrelloImport.downloadBoardJson(options);
         if (program.jsonDebugOutput) {
           console.log("Trello board JSON:", JSON.stringify(boardJson, null, 2));
         } else {
@@ -88,7 +89,7 @@ async function importer(program: ZlImportOptions): Promise<void> {
         await fsPromises.mkdir(program.outputFolder, { recursive: true });
         await fsPromises.writeFile(tempFile, JSON.stringify(boardJson, null, 2));
         // Now import as usual
-        response = await (new TrelloImport).importAsync(tempFile, program.outputFolder);
+        response = await (new TrelloImport).importAsync(tempFile, program.outputFolder, options);
       } catch (err: any) {
         console.error("Failed to process Trello board:", err.message || err);
         response = { success: false, message: "Failed to process Trello board: " + (err.message || err) };
@@ -96,7 +97,7 @@ async function importer(program: ZlImportOptions): Promise<void> {
     } else {
       switch (program.source) {
         case "trello":
-          response = await (new TrelloImport).importAsync(program.path, program.outputFolder);
+          response = await (new TrelloImport).importAsync(program.path, program.outputFolder, options);
           break;
         case "unknown":
           await delay(100);

--- a/src/zl-import.ts
+++ b/src/zl-import.ts
@@ -75,9 +75,6 @@ async function importer(program: ZlImportOptions): Promise<void> {
       program.trelloApiKey &&
       program.trelloBoard
     ) {
-      options.apiKey = program.trelloApiKey;
-      options.boardIdOrName = program.trelloBoard;
-      options.token = program.trelloToken;
 
       // Download board JSON from Trello API using TrelloImport helper
       try {


### PR DESCRIPTION
Fixes #795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched networking to the runtime fetch API for board and attachment retrieval, simplifying HTTP handling.

* **Tests**
  * Updated unit tests and mocks to use fetch-based responses and adjusted assertions for the new request behaviour, including additional failure scenarios.

* **Chores**
  * Removed an external HTTP library from project dependencies and added a TypeScript type-check lint script.

* **User-facing**
  * Import tooling now accepts a consolidated options object (including verbose and Trello settings) passed through import operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->