### PR TITLE
Install older npm in publish due to regression in `npm@latest` install from node 22

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,8 +48,9 @@ jobs:
       # Expected removal: 2026-Q3
       - run: npm install -g npm@10.9.8
 
-      # Ensure npm 11.5.1 or later is installed
-      - run: npm install -g npm@latest
+      # Ensure npm 11.5.1+ while keeping behaviour deterministic
+      - run: npm install -g npm@^11.5.1
+      - run: npm --version
       - run: npm ci
       - run: npm run-script create
       - run: npm publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,6 +38,10 @@ jobs:
           node-version: 22
           cache: npm
           registry-url: https://registry.npmjs.org/
+      
+      # Install legacy npm first, as a workaround for https://github.com/nodejs/node/issues/62425
+      - run: npm install -g npm@10.9.8
+
       # Ensure npm 11.5.1 or later is installed
       - run: npm install -g npm@latest
       - run: npm ci

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,10 @@ permissions:
 
 concurrency:
   group: npm-publish-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: 22
 
 jobs:
   build:
@@ -23,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -35,11 +38,14 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           registry-url: https://registry.npmjs.org/
       
       # Install legacy npm first, as a workaround for https://github.com/nodejs/node/issues/62425
+      # TODO(fix-node-22): Remove npm v10.9.8 workaround when Node 22.x > 22.22.2 or when 
+      # nodejs/node#62425 is resolved. Check status periodically.
+      # Expected removal: 2026-Q3
       - run: npm install -g npm@10.9.8
 
       # Ensure npm 11.5.1 or later is installed
@@ -47,18 +53,3 @@ jobs:
       - run: npm ci
       - run: npm run-script create
       - run: npm publish
-
-
-  # publish-gpr:
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 22
-  #         registry-url: https://npm.pkg.github.com/
-  #     - run: npm ci
-  #     - run: npm publish
-  #       env:
-  #         NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
https://github.com/nodejs/node/issues/62425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Modernised the package publishing workflow to use Node.js 22 and updated build tooling configuration for enhanced reliability and security during release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->