### PR TITLE
ci: run Codacy workflow on all pull requests

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -17,8 +17,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
     - cron: '26 10 * * 6'
 

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -17,6 +17,8 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
   schedule:
     - cron: '26 10 * * 6'
 
@@ -98,5 +100,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: ${{ matrix.sarif_file }}
-          category: codacy-${{ strategy.job-index }}
+          category: codacy
           wait-for-processing: true


### PR DESCRIPTION
Allow the Codacy workflow to run on pull requests targeting branches other than `main` so code-scanning SARIF is uploaded for PRs and GitHub Advanced Security can determine PR alerts.

This removes the restrictive `branches: [ "main" ]` filter under the `pull_request` trigger in `.github/workflows/codacy.yml`.